### PR TITLE
Add missing font copyright info to OFL.txt

### DIFF
--- a/OFL.txt
+++ b/OFL.txt
@@ -1,9 +1,9 @@
 Copyright 20** The Unified Font Repository Project Authors (https://github.com/googlefonts/Unified-Font-Repository)
 
-
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
 https://scripts.sil.org/OFL
+
 
 SIL Open Font License v1.1
 ====================================================

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,8 +1,9 @@
 Copyright 20** The Unified Font Repository Project Authors (https://github.com/googlefonts/Unified-Font-Repository)
 
+
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-http://scripts.sil.org/OFL
+https://scripts.sil.org/OFL
 
 SIL Open Font License v1.1
 ====================================================

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,3 +1,5 @@
+Copyright 20** The Unified Font Repository Project Authors (https://github.com/googlefonts/Unified-Font-Repository)
+
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
 http://scripts.sil.org/OFL


### PR DESCRIPTION
The Google Fonts spec has a section requiring font copyright info in the first line of the OFL: https://github.com/googlefonts/gf-docs/tree/main/Spec#font-copyright