### PR TITLE
Clarify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Short description of your font goes here.
 
 Fonts are built automatically by GitHub Actions - take a look in the "Actions" tab for the latest build.
 
-If you want to build fonts manually on your own computer, you will need to install the [`yq` utility](https://github.com/mikefarah/yq). On OS X with Homebrew, type `brew install yq`; on Linux, try `snap install yq`; if all else fails, try the instructions on the linked page.
+If you want to build fonts manually on your own computer, you will need to install the [`yq` utility](https://github.com/mikefarah/yq). On macOS with Homebrew, type `brew install yq`; on Linux, try `snap install yq`; if all else fails, try the instructions on the on the [`yq` GitHub](https://github.com/mikefarah/yq) page [here](https://github.com/mikefarah/yq#install).
 
 Then:
 


### PR DESCRIPTION
- macOS is a clearer term than OS X.
- The suggestion to `try the instructions on the linked page` is unclear, better to link directly to the installation instructions to avoid confusion.