### PR TITLE
Remove yq, use pure-Python parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-SOURCES=$(shell yq e '.sources.[] | sub("^","sources/")' sources/config.yaml )
-FAMILY=$(shell yq e '.familyName' sources/config.yaml )
-
+SOURCES=$(shell python3 scripts/read-config.py --sources )
+FAMILY=$(shell python3 scripts/read-config.py --family )
 help:
 	@echo "###"
 	@echo "# Build targets for $(FAMILY)"

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ proof: venv build.stamp
 
 clean:
 	rm -rf venv
-	find -iname "*.pyc" -delete
+	find . -name "*.pyc" | xargs rm delete

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ Description of you and/or organisation goes here.
 
 Fonts are built automatically by GitHub Actions - take a look in the "Actions" tab for the latest build.
 
-If you want to build fonts manually on your own computer, you will need to install the [`yq` utility](https://github.com/mikefarah/yq). On macOS with Homebrew, type `brew install yq`; on Linux, try `snap install yq`; if all else fails, try the instructions on the on the [`yq` GitHub](https://github.com/mikefarah/yq) page [here](https://github.com/mikefarah/yq#install).
-
-Then:
+If you want to build fonts manually on your own computer:
 
 * `make build` will produce font files.
 * `make test` will run [FontBakery](https://github.com/googlefonts/fontbakery)'s quality assurance tests.

--- a/scripts/read-config.py
+++ b/scripts/read-config.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Yes, this is a Bad YAML Parser, but at this stage we are not in the
+# venv and do not know what modules the user has available, so for
+# maximum compatibility, we are just assuming a plain Python distribution.
+import argparse
+import re
+import sys
+
+parser = argparse.ArgumentParser()
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--sources',action='store_true')
+group.add_argument('--family',action='store_true')
+args = parser.parse_args()
+
+with open("sources/config.yaml") as config:
+	data = config.read()
+
+if args.family:
+	m = re.search(r"(?m)^familyName: (.*)", data)
+	if m:
+		print(m[1])
+		sys.exit(0)
+	else:
+		print("Could not determine family name from config file!")
+		sys.exit(1)
+
+toggle = False
+sources = []
+for line in data.splitlines():
+	if re.match("^sources:", line):
+		toggle = True
+		continue
+	if toggle:
+		m = re.match(r"^\s+-\s*(.*)", line)
+		if m:
+			sources.append("sources/"+m[1])
+		else:
+			toggle = False
+if sources:
+	print(" ".join(sources))
+	sys.exit(0)
+else:
+	print("Could not determine sources from config file!")
+	sys.exit(1)

--- a/scripts/read-config.py
+++ b/scripts/read-config.py
@@ -5,6 +5,7 @@
 import argparse
 import re
 import sys
+import os
 
 parser = argparse.ArgumentParser()
 group = parser.add_mutually_exclusive_group(required=True)
@@ -12,7 +13,7 @@ group.add_argument('--sources',action='store_true')
 group.add_argument('--family',action='store_true')
 args = parser.parse_args()
 
-with open("sources/config.yaml") as config:
+with open(os.path.join("sources", "config.yaml")) as config:
 	data = config.read()
 
 if args.family:


### PR DESCRIPTION
This should make things more compatible and easier to install:

- Use python script instead of yq
- More compatible (BSD-friendly) find
