### PR TITLE
Add node_modules to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv
 build.stamp
 proof
 fonts
+node_modules
 
 # OS generated files #
 ######################

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build.stamp
 proof
 fonts
 node_modules
+package-lock.json
+package.json
 
 # OS generated files #
 ######################


### PR DESCRIPTION
The steps to fix `make update-ufr` issue: https://github.com/googlefonts/Unified-Font-Repository/issues/39 create a `node_modules` directory in the UFR root directory.

Adding this line to the `.gitignore` will help prevent this from getting added to a font's Git repo.