### PR TITLE
Pin dependencies when initialising a repo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
       name: First-run setup
       if: github.repository != 'googlefonts/Unified-Font-Repository'
       with:
-        file_pattern: .init.stamp README.md
+        file_pattern: .init.stamp README.md requirements.txt
     - name: gen zip file name
       id: zip-name
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,6 @@ clean:
 
 update-ufr:
 	npx update-template https://github.com/googlefonts/Unified-Font-Repository/
+
+update:
+	pip install --upgrade $(dependency); pip freeze > requirements.txt

--- a/scripts/first-run.py
+++ b/scripts/first-run.py
@@ -8,6 +8,7 @@ from sh import git
 import re
 import sys
 from urllib.parse import quote
+import subprocess
 
 BASE_OWNER = "googlefonts"
 BASE_REPONAME = "Unified-Font-Repository"
@@ -68,6 +69,8 @@ if owner == BASE_OWNER and reponame == BASE_REPONAME:
 # and badges about their own font, not ours! So any URLs need to be adjusted to
 # refer to the end user's repository.
 
+# We will also pin the dependencies so future builds are reproducible.
+
 readme = open("README.md").read()
 
 print(
@@ -89,6 +92,12 @@ readme = readme.replace(
 
 with open("README.md", "w") as fh:
     fh.write(readme)
+
+# Pin the dependencies
+print("Pinning dependencies")
+dependencies = subprocess.check_output(["pip", "freeze"])
+with open("requirements.txt", "wb") as dependency_file:
+    dependency_file.write(dependencies)
 
 # Finally, we add a "touch file" called ".init.stamp" to the repository which
 # prevents this first-run process from being run again.


### PR DESCRIPTION
I've also included a cmd in the makefile to update a dependency e.g

`make update dependency=fontmake`

Running the above will update fontmake to the latest version and then rewrite the requirements.txt file.

Fixes #58 