### PR TITLE
Limit CI triggers to avoid duplicate runs on PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -66,7 +66,7 @@ jobs:
       run: cp scripts/index.html out/index.html
     - name: Collect deployment assets
       if: ${{ github.ref == 'refs/heads/main' }}
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: ./out
     - name: Archive artifacts
@@ -110,7 +110,7 @@ jobs:
       ZIP_NAME: ${{ needs.build.outputs.zip_name }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use font artifacts from CI
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
Same refs spin up CI twice for both being the branch head, and the PR head:

> <img width="1080" height="156" alt="Screenshot 2025-09-08 at 17 38 21" src="https://github.com/user-attachments/assets/25e389d9-fe20-4a37-854b-5b419143dd48" />

which is not really necessary. (And can even introduce confusion, as branch pushes run in the context of the repo branch and the actual sha, whereas PR triggers run unprivileged and on "merge head", i.e. the future ref that would happen after merging — showing better forward compatibility before any surprises land on main…)

This simplifies that by limiting the runs to just the default branch (and tags), and PR pushes separately.

(Also bumps all actions versions to current major releases).

Test runs of the template repository on push and tag:

| Merge | Release |
|--------|--------|
| <img width="1210" height="730" alt="Screenshot 2025-09-08 at 17 39 25" src="https://github.com/user-attachments/assets/f5109b13-2141-4d32-959e-aab6f1d57ba5" /> | <img width="1238" height="696" alt="Screenshot 2025-09-08 at 17 39 47" src="https://github.com/user-attachments/assets/a873e965-a992-4bef-b685-c439a00227c8" /> |

(Also closes #204 and resolves #203 as superseded.)