### PR TITLE
rm redundant copy file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: Build font and specimen
 
 on: [push, pull_request, workflow_dispatch]
+permissions: write-all
 
 jobs:
   build:


### PR DESCRIPTION
#208 forgot to update the workflow. We need this merged or the ci fails when it tries to make a release.