### PR TITLE
Add subset-files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ package-lock.json
 package.json
 master_ufo
 instance_ufos
+subset-files
 .ninja_log
 build.ninja
 


### PR DESCRIPTION
This folder is created by gftools when using the addSubset operation. It can't be customised or modified that I know of, so it makes sense to include it in the ignore, as you're not meant to commit these pulled in sources