### PR TITLE
Add support for deploying from different default branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - master  # for backwards compatibility; use your default branch if different
     tags:
       - '*'
 
@@ -65,7 +66,7 @@ jobs:
     - name: Set up test result site
       run: cp scripts/index.html out/index.html
     - name: Collect deployment assets
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref_name == github.event.repository.default_branch }}
       uses: actions/upload-pages-artifact@v4
       with:
         path: ./out
@@ -81,7 +82,7 @@ jobs:
 
   deploy:
     name: Deploy results to GitHub Pages
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -103,7 +104,7 @@ jobs:
 
   release:
     name: Release bundle
-    if: contains(github.ref, 'refs/tags/')
+    if: ${{ github.ref_type == 'tag' }}
     needs: build
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This is mainly for consumers still using the old default branch name, with a comment hinting at the place that might need tweaking further if they use completely custom branch names.

(There's not much risk of a collision if someone has both push trigger refs, as the subsequent conditions only ever attempt to publish based on being on the default branch — expecting to match the implicit branch protection rules added for GHA-based Pages environments.)

Resolves https://github.com/googlefonts/googlefonts-project-template/issues/211#issuecomment-3729500814

Example runs for main:

> <img width="1204" height="736" alt="deploy" src="https://github.com/user-attachments/assets/7b426fcf-2004-4027-818d-4ccd5550bffc" />

and for release:

> <img width="1186" height="692" alt="release" src="https://github.com/user-attachments/assets/0ec657f4-0049-456f-a56c-ce3fcaf97bcb" />
