### PR TITLE
Add venv cache versioning to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
+      id: python
       with:
         python-version: "3.11"
     - name: Setup fontspector
@@ -34,9 +35,9 @@ jobs:
     - uses: actions/cache@v4
       with:
         path: ./venv/
-        key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
+        key: ${{ runner.os }}-venv${{ steps.python.outputs.python-version }}-${{ hashFiles('**/requirements*.txt') }}
         restore-keys: |
-          ${{ runner.os }}-venv-
+          ${{ runner.os }}-venv${{ steps.python.outputs.python-version }}-
     - name: Set artifact file name
       id: zip-name
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
       run: cp scripts/index.html out/index.html
     - name: Collect deployment assets
       if: ${{ github.ref_name == github.event.repository.default_branch }}
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v5
       with:
         path: ./out
     - name: Archive artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install ttfautohint libcairo2-dev python3-cairo-dev pkg-config python3-dev
         sudo snap install yq
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ./venv/
         key: ${{ runner.os }}-venv${{ steps.python.outputs.python-version }}-${{ hashFiles('**/requirements*.txt') }}
@@ -72,7 +72,7 @@ jobs:
       with:
         path: ./out
     - name: Archive artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ env.ZIP_NAME }}
         path: |
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   # There are two ways a release can be created: either by pushing a tag, or by
   # creating a release from the GitHub UI. Pushing a tag does not automatically
@@ -114,7 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Use font artifacts from CI
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.ZIP_NAME }}
           path: ${{ env.ZIP_NAME }}


### PR DESCRIPTION
To avoid CI failures during template upgrades (or just Python bumps if consumers do so) the venv created using older Python version must not be restored from cache.

Adding a Python version key seems easier than trying to document the fact consumers need to remember manually going into their Actions looking into the right Caches and deleting all of them (which also needs certain permissions for the repo, so can't be e.g. ensured from just a PR doing the upgrade etc.)

Doing some extra/fragile shenanigans to be more lax and only key to major.minor could be viable, but this achieves precise version for the sake of simplicity, given older Python versions don't really get frequent updates (compared to the useful cache lifetime):


| <img width="528" height="288" alt="venv" src="https://github.com/user-attachments/assets/11164714-da6b-4fdb-9b2a-334efdf5c8a1" /> | <img width="876" height="414" alt="cache" src="https://github.com/user-attachments/assets/e3c945f4-8f9c-428c-832b-44e0ec024c3b" /> |
|--------|--------|

This also updates actions versions to prepare for upcoming runner deprecations.
